### PR TITLE
Adding Royal Mail (UK) support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # linkify-tracking
-Linkifies package tracking numbers for DHL, FedEx, UPS, and USPS
+Linkifies package tracking numbers for DHL, FedEx, UPS, USPS, and Royal Mail (UK)
 
 ## Installation
 

--- a/src/LinkifyTracking.php
+++ b/src/LinkifyTracking.php
@@ -36,6 +36,11 @@ class LinkifyTracking
                 '/\b((M|P[A-Z]?|D[C-Z]|LK|E[A-C]|V[A-Z]|R[A-Z]|CP|CJ|LC|LJ) ?\d{3} ?\d{3} ?\d{3} ?[A-Z]?[A-Z]?)\b/i',
                 '/\b(82 ?\d{3} ?\d{3} ?\d{2})\b/i'
             ]
+        ],
+        [
+            'label' => 'Royal Mail',
+            'url' => 'http://www.royalmail.com/portal/rm/track?trackNumber=%s',
+            'regex' => '/\b(?!(EA|EB|EC|ED|EE|CP))[A-Za-z]{2}[0-9]{9}+GB\b/i'
         ]
     ];
 


### PR DESCRIPTION
@philipnewcomer here is a new Regex addition to support Royal Mail.

Credit for regular expression goes to the following.

https://stackoverflow.com/questions/619977/regular-expression-patterns-for-tracking-numbers#comment72959831_3537055

https://www.royalmail.com/royal-mail-you/intellectual-property-rights/linking-our-website