### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0
+- Ensure generated URLs are properly formatted (via `rawurlencode()`)
+- Sort regular expressions by specificity to decrease likelihood of partial matches when using `LinkifyTracking::linkify()`.
+- Prevent double linkification when using `LinkifyTracking::linkify()`.
+- Update DHL tracking number patterns based on information available [here](https://www.dhl.com/us-en/home/tracking/id-labels.html). Due to ambiguity, some patterns are intentionally broad.
+
 ## 1.1.0
  - Added Royal Mail (UK) support
 

--- a/src/LinkifyTracking.php
+++ b/src/LinkifyTracking.php
@@ -33,15 +33,26 @@ class LinkifyTracking
             'regex' => '/\b(((96\d\d|6\d)\d{3} ?\d{4}|96\d{2}|\d{4}) ?\d{4} ?\d{4}( ?\d{3})?)\b/i'
         ],
 		[
+			'label' => 'Royal Mail',
+			'url' => 'http://www.royalmail.com/portal/rm/track?trackNumber=%s',
+			'regex' => '/\b(?!(EA|EB|EC|ED|EE|CP))[A-Za-z]{2}[0-9]{9}+GB\b/i'
+		],
+		[
 			'label' => 'DHL',
 			'url' => 'http://www.dhl.com/content/g0/en/express/tracking.shtml?brand=DHL&AWB=%s',
-			'regex' => '/\b(\d{4}[- ]?\d{4}[- ]?\d{2}|\d{3}[- ]?\d{8}|[A-Z]{3}\d{7})\b/i'
-		],
-        [
-            'label' => 'Royal Mail',
-            'url' => 'http://www.royalmail.com/portal/rm/track?trackNumber=%s',
-            'regex' => '/\b(?!(EA|EB|EC|ED|EE|CP))[A-Za-z]{2}[0-9]{9}+GB\b/i'
-        ]
+			'regex' => [
+				'/\b\d{7}\b/i',
+				'/\b\d{9}\b/i',
+				'/\b\d{10}\b/i',
+				'/\b\d{14}\b/i',
+				'/\b[A-Z]{2,5}\d{8,39}\b/i',
+				'/\b(?:000|3S|JJD|JJD00|JJD01|JVGL)[A-Z0-9]{8,39}\b/i',
+				'/\b\d{1}[A-Z]{2}\d{4,6}\b/i',
+				'/\b\d{3}-\d{8}\b/i',
+				'/\b(?:[A-Z]{2,3}-){2}\d{7}\b/i',
+				'/\b(\d{4}[- ]?\d{4}[- ]?\d{2}|\d{3}[- ]?\d{8}|[A-Z]{3}\d{7})\b/i'
+			]
+		]
     ];
 
     /**

--- a/src/LinkifyTracking.php
+++ b/src/LinkifyTracking.php
@@ -13,46 +13,46 @@ class LinkifyTracking
      * @var array The tracking carriers, sorted by pattern specificity (descending).
      */
     protected $carriers = [
-		[
-			'label' => 'USPS',
-			'url' => 'https://tools.usps.com/go/TrackConfirmAction?tLabels=%s',
-			'regex' => [
-				'/\b((420 ?\d{5} ?)?(91|92|93|94|01|03|04|70|23|13)\d{2} ?\d{4} ?\d{4} ?\d{4} ?\d{4}( ?\d{2,6})?)\b/i',
-				'/\b((M|P[A-Z]?|D[C-Z]|LK|E[A-C]|V[A-Z]|R[A-Z]|CP|CJ|LC|LJ) ?\d{3} ?\d{3} ?\d{3} ?[A-Z]?[A-Z]?)\b/i',
-				'/\b(82 ?\d{3} ?\d{3} ?\d{2})\b/i'
-			]
-		],
-		[
-			'label' => 'UPS',
-			'url' => 'http://wwwapps.ups.com/WebTracking/processInputRequest?TypeOfInquiryNumber=T&InquiryNumber1=%s',
-			'regex' => '/\b(1Z ?[0-9A-Z]{3} ?[0-9A-Z]{3} ?[0-9A-Z]{2} ?[0-9A-Z]{4} ?[0-9A-Z]{3} ?[0-9A-Z]|T\d{3} ?\d{4} ?\d{3})\b/i'
-		],
+        [
+            'label' => 'USPS',
+            'url' => 'https://tools.usps.com/go/TrackConfirmAction?tLabels=%s',
+            'regex' => [
+                '/\b((420 ?\d{5} ?)?(91|92|93|94|01|03|04|70|23|13)\d{2} ?\d{4} ?\d{4} ?\d{4} ?\d{4}( ?\d{2,6})?)\b/i',
+                '/\b((M|P[A-Z]?|D[C-Z]|LK|E[A-C]|V[A-Z]|R[A-Z]|CP|CJ|LC|LJ) ?\d{3} ?\d{3} ?\d{3} ?[A-Z]?[A-Z]?)\b/i',
+                '/\b(82 ?\d{3} ?\d{3} ?\d{2})\b/i',
+            ],
+        ],
+        [
+            'label' => 'UPS',
+            'url' => 'http://wwwapps.ups.com/WebTracking/processInputRequest?TypeOfInquiryNumber=T&InquiryNumber1=%s',
+            'regex' => '/\b(1Z ?[0-9A-Z]{3} ?[0-9A-Z]{3} ?[0-9A-Z]{2} ?[0-9A-Z]{4} ?[0-9A-Z]{3} ?[0-9A-Z]|T\d{3} ?\d{4} ?\d{3})\b/i',
+        ],
         [
             'label' => 'FedEx',
             'url' => 'https://www.fedex.com/apps/fedextrack/?action=track&locale=en_US&cntry_code=us&tracknumbers=%s',
-            'regex' => '/\b(((96\d\d|6\d)\d{3} ?\d{4}|96\d{2}|\d{4}) ?\d{4} ?\d{4}( ?\d{3})?)\b/i'
+            'regex' => '/\b(((96\d\d|6\d)\d{3} ?\d{4}|96\d{2}|\d{4}) ?\d{4} ?\d{4}( ?\d{3})?)\b/i',
         ],
-		[
-			'label' => 'Royal Mail',
-			'url' => 'http://www.royalmail.com/portal/rm/track?trackNumber=%s',
-			'regex' => '/\b(?!(EA|EB|EC|ED|EE|CP))[A-Za-z]{2}[0-9]{9}+GB\b/i'
-		],
-		[
-			'label' => 'DHL',
-			'url' => 'http://www.dhl.com/content/g0/en/express/tracking.shtml?brand=DHL&AWB=%s',
-			'regex' => [
-				'/\b\d{7}\b/i',
-				'/\b\d{9}\b/i',
-				'/\b\d{10}\b/i',
-				'/\b\d{14}\b/i',
-				'/\b[A-Z]{2,5}\d{8,39}\b/i',
-				'/\b(?:000|3S|JJD|JJD00|JJD01|JVGL)[A-Z0-9]{8,39}\b/i',
-				'/\b\d{1}[A-Z]{2}\d{4,6}\b/i',
-				'/\b\d{3}-\d{8}\b/i',
-				'/\b(?:[A-Z]{2,3}-){2}\d{7}\b/i',
-				'/\b(\d{4}[- ]?\d{4}[- ]?\d{2}|\d{3}[- ]?\d{8}|[A-Z]{3}\d{7})\b/i'
-			]
-		]
+        [
+            'label' => 'Royal Mail',
+            'url' => 'http://www.royalmail.com/portal/rm/track?trackNumber=%s',
+            'regex' => '/\b(?!(EA|EB|EC|ED|EE|CP))[A-Za-z]{2}[0-9]{9}+GB\b/i',
+        ],
+        [
+            'label' => 'DHL',
+            'url' => 'http://www.dhl.com/content/g0/en/express/tracking.shtml?brand=DHL&AWB=%s',
+            'regex' => [
+                '/\b\d{7}\b/i',
+                '/\b\d{9}\b/i',
+                '/\b\d{10}\b/i',
+                '/\b\d{14}\b/i',
+                '/\b[A-Z]{2,5}\d{8,39}\b/i',
+                '/\b(?:000|3S|JJD|JJD00|JJD01|JVGL)[A-Z0-9]{8,39}\b/i',
+                '/\b\d{1}[A-Z]{2}\d{4,6}\b/i',
+                '/\b\d{3}-\d{8}\b/i',
+                '/\b(?:[A-Z]{2,3}-){2}\d{7}\b/i',
+                '/\b(\d{4}[- ]?\d{4}[- ]?\d{2}|\d{3}[- ]?\d{8}|[A-Z]{3}\d{7})\b/i',
+            ],
+        ],
     ];
 
     /**
@@ -89,8 +89,8 @@ class LinkifyTracking
     public function getLinkData(string $trackingNumber)
     {
         foreach ($this->carriers as $carrier) {
-            foreach ((array) $carrier['regex'] as $regex) {
-                if (! preg_match($regex, $trackingNumber, $matches)) {
+            foreach ((array)$carrier['regex'] as $regex) {
+                if (!preg_match($regex, $trackingNumber, $matches)) {
                     continue;
                 }
 
@@ -102,7 +102,7 @@ class LinkifyTracking
 
                 return [
                     'carrier' => $carrier['label'],
-                    'url' => sprintf($carrier['url'], rawurlencode($matches[0]))
+                    'url' => sprintf($carrier['url'], rawurlencode($matches[0])),
                 ];
             }
         }
@@ -119,13 +119,14 @@ class LinkifyTracking
      */
     public function linkify(string $content)
     {
-    	$linkficationQueue = [];
+        $linkficationQueue = [];
         foreach ($this->carriers as $carrier) {
-            foreach ((array) $carrier['regex'] as $regex) {
+            foreach ((array)$carrier['regex'] as $regex) {
                 $content = preg_replace_callback(
                     $regex,
                     function ($matches) use (&$linkficationQueue, $carrier) {
-						$linkficationQueue[] = $this->generateHtmlLink($carrier, $matches[0]);
+                        $linkficationQueue[] = $this->generateHtmlLink($carrier, $matches[0]);
+
                         return '%s';
                     },
                     $content
@@ -133,13 +134,13 @@ class LinkifyTracking
             }
         }
 
-		return sprintf($content, ...$linkficationQueue);
+        return sprintf($content, ...$linkficationQueue);
     }
 
     /**
      * Generates an HTML link to the given carrier for the given tracking number.
      *
-     * @param array $carrier
+     * @param array  $carrier
      * @param string $trackingNumber
      *
      * @return string
@@ -148,7 +149,7 @@ class LinkifyTracking
     {
         $attributes = array_merge(
             [
-                'href' => sprintf($carrier['url'], rawurlencode($trackingNumber))
+                'href' => sprintf($carrier['url'], rawurlencode($trackingNumber)),
             ],
             $this->args['linkAttributes'] ?? []
         );

--- a/src/LinkifyTracking.php
+++ b/src/LinkifyTracking.php
@@ -91,7 +91,7 @@ class LinkifyTracking
 
                 return [
                     'carrier' => $carrier['label'],
-                    'url' => sprintf($carrier['url'], $matches[0])
+                    'url' => sprintf($carrier['url'], rawurlencode($matches[0]))
                 ];
             }
         }
@@ -135,7 +135,7 @@ class LinkifyTracking
     {
         $attributes = array_merge(
             [
-                'href' => sprintf($carrier['url'], $trackingNumber)
+                'href' => sprintf($carrier['url'], rawurlencode($trackingNumber))
             ],
             $this->args['linkAttributes'] ?? []
         );

--- a/src/LinkifyTracking.php
+++ b/src/LinkifyTracking.php
@@ -10,33 +10,33 @@ class LinkifyTracking
     protected $args;
 
     /**
-     * @var array The tracking carriers.
+     * @var array The tracking carriers, sorted by pattern specificity (descending).
      */
     protected $carriers = [
-        [
-            'label' => 'DHL',
-            'url' => 'http://www.dhl.com/content/g0/en/express/tracking.shtml?brand=DHL&AWB=%s',
-            'regex' => '/\b(\d{4}[- ]?\d{4}[- ]?\d{2}|\d{3}[- ]?\d{8}|[A-Z]{3}\d{7})\b/i'
-        ],
+		[
+			'label' => 'USPS',
+			'url' => 'https://tools.usps.com/go/TrackConfirmAction?tLabels=%s',
+			'regex' => [
+				'/\b((420 ?\d{5} ?)?(91|92|93|94|01|03|04|70|23|13)\d{2} ?\d{4} ?\d{4} ?\d{4} ?\d{4}( ?\d{2,6})?)\b/i',
+				'/\b((M|P[A-Z]?|D[C-Z]|LK|E[A-C]|V[A-Z]|R[A-Z]|CP|CJ|LC|LJ) ?\d{3} ?\d{3} ?\d{3} ?[A-Z]?[A-Z]?)\b/i',
+				'/\b(82 ?\d{3} ?\d{3} ?\d{2})\b/i'
+			]
+		],
+		[
+			'label' => 'UPS',
+			'url' => 'http://wwwapps.ups.com/WebTracking/processInputRequest?TypeOfInquiryNumber=T&InquiryNumber1=%s',
+			'regex' => '/\b(1Z ?[0-9A-Z]{3} ?[0-9A-Z]{3} ?[0-9A-Z]{2} ?[0-9A-Z]{4} ?[0-9A-Z]{3} ?[0-9A-Z]|T\d{3} ?\d{4} ?\d{3})\b/i'
+		],
         [
             'label' => 'FedEx',
             'url' => 'https://www.fedex.com/apps/fedextrack/?action=track&locale=en_US&cntry_code=us&tracknumbers=%s',
             'regex' => '/\b(((96\d\d|6\d)\d{3} ?\d{4}|96\d{2}|\d{4}) ?\d{4} ?\d{4}( ?\d{3})?)\b/i'
         ],
-        [
-            'label' => 'UPS',
-            'url' => 'http://wwwapps.ups.com/WebTracking/processInputRequest?TypeOfInquiryNumber=T&InquiryNumber1=%s',
-            'regex' => '/\b(1Z ?[0-9A-Z]{3} ?[0-9A-Z]{3} ?[0-9A-Z]{2} ?[0-9A-Z]{4} ?[0-9A-Z]{3} ?[0-9A-Z]|T\d{3} ?\d{4} ?\d{3})\b/i'
-        ],
-        [
-            'label' => 'USPS',
-            'url' => 'https://tools.usps.com/go/TrackConfirmAction?tLabels=%s',
-            'regex' => [
-                '/\b((420 ?\d{5} ?)?(91|92|93|94|01|03|04|70|23|13)\d{2} ?\d{4} ?\d{4} ?\d{4} ?\d{4}( ?\d{2,6})?)\b/i',
-                '/\b((M|P[A-Z]?|D[C-Z]|LK|E[A-C]|V[A-Z]|R[A-Z]|CP|CJ|LC|LJ) ?\d{3} ?\d{3} ?\d{3} ?[A-Z]?[A-Z]?)\b/i',
-                '/\b(82 ?\d{3} ?\d{3} ?\d{2})\b/i'
-            ]
-        ],
+		[
+			'label' => 'DHL',
+			'url' => 'http://www.dhl.com/content/g0/en/express/tracking.shtml?brand=DHL&AWB=%s',
+			'regex' => '/\b(\d{4}[- ]?\d{4}[- ]?\d{2}|\d{3}[- ]?\d{8}|[A-Z]{3}\d{7})\b/i'
+		],
         [
             'label' => 'Royal Mail',
             'url' => 'http://www.royalmail.com/portal/rm/track?trackNumber=%s',
@@ -108,19 +108,21 @@ class LinkifyTracking
      */
     public function linkify(string $content)
     {
+    	$linkficationQueue = [];
         foreach ($this->carriers as $carrier) {
             foreach ((array) $carrier['regex'] as $regex) {
                 $content = preg_replace_callback(
                     $regex,
-                    function ($matches) use ($carrier) {
-                        return $this->generateHtmlLink($carrier, $matches[0]);
+                    function ($matches) use (&$linkficationQueue, $carrier) {
+						$linkficationQueue[] = $this->generateHtmlLink($carrier, $matches[0]);
+                        return '%s';
                     },
                     $content
                 );
             }
         }
 
-        return $content;
+		return sprintf($content, ...$linkficationQueue);
     }
 
     /**


### PR DESCRIPTION
Hello,

I have implemented a number of useful (but backwards-incompatible) fixes and improvements. They are included in the changelog. They are also listed (with brief explanations) below.

### Ensure generated URLs are properly formatted (via `rawurlencode()`)

Before this change, generated URLs were technically incorrect if a tracking number had spaces in it. Browsers can typically correct for this by encoding the URL's special characters under the hood, but A) not all browsers do this, and B) any programmatic URL verification (e.g. when using Symfony's [`UrlType`](https://symfony.com/doc/current/reference/forms/types/url.html) field) would fail.

I opted for `rawurlencode()` instead of `urlencode()` because some websites (e.g. DHL's tracking website) interpret plus signs (+) literally.

### Sort regular expressions by specificity to decrease likelihood of partial matches when using `LinkifyTracking::linkify()`.

If two patterns exist—`ABC` and `ABCABC`—the first pattern would previously be matched earlier, resulting in the latter not being found. Note that I only loosely improved this—I suspect there is still overlap, especially when you consider that carriers can have multiple patterns. I spent about two seconds looking at it and then moved on.

### Prevent double linkification when using `LinkifyTracking::linkify()`.

Similar to the previous issue, if one tracking number was linkified but then a subsequent pattern still matched it, the links would be created twice. Now, each replacement is added to a "linkification queue" that stores the replacements that need to be made. To prevent duplication, each match is temporarily replaced with `%s`. Once all matches have been made, the replacement values stored in the linkification queue are used to finalize the result.

### Update DHL tracking number patterns based on information available [here](https://www.dhl.com/us-en/home/tracking/id-labels.html). Due to ambiguity, some patterns are intentionally broad.

Title says all. Some could probably be improved to reduce redundancy, but that's a job for another day. Also, I think DHL tracks different types of shipments via different URLs, so we should look into that too.

...

Future changes should probably include adding some tests, adding more specific type hints/annotations, fixing pattern specificity, fixing pattern redundancy, and fixing DHL tracking URLs since I believe they have multiple. We should probably add a minimum PHP requirement to Composer as well. I did none of these things.

Let me know if you have any questions.